### PR TITLE
chore: update README with current file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OwnerOrPwned
-Complementary files and scripts for a Trimarc whitepaper.
+Complementary files and scripts for the "Owner or Pwned?" whitepaper.
 
-Whitepaper can be viewed at either: https://www.hub.trimarcsecurity.com/post/trimarc-whitepaper-owner-or-pwnd
-OR
-https://github.com/Trimarc/papers/blob/main/OwnerOrPwned-JimSykora.pdf
+Whitepaper can be viewed at: https://adminsdholder.com/files/Owner_or_Pwned_v1.3_JimSykora.pdf
+
+Originally published at:
+* https://www.hub.trimarcsecurity.com/post/trimarc-whitepaper-owner-or-pwnd
+* https://github.com/Trimarc/papers/blob/main/OwnerOrPwned-JimSykora.pdf


### PR DESCRIPTION
Newest file now lives @ [adminsdholder.com](https://adminsdholder.com).
Converted Trimarc links to references.